### PR TITLE
logging and discovery fix

### DIFF
--- a/custom_components/ac_infinity/config_flow.py
+++ b/custom_components/ac_infinity/config_flow.py
@@ -99,11 +99,17 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="no_devices_found")
 
         devices = {}
+        _LOGGER.debug(f"self._discovered_devices: {self._discovered_devices}")
         for service_info in self._discovered_devices.values():
-            device = parse_manufacturer_data(
-                service_info.advertisement.manufacturer_data[MANUFACTURER_ID]
-            )
-            devices[service_info.address] = f"{device.name} ({service_info.address})"
+            _LOGGER.debug(f"service_info: {service_info.advertisement.manufacturer_data}")
+            try:
+                device = parse_manufacturer_data(
+                    service_info.advertisement.manufacturer_data[MANUFACTURER_ID]
+                )
+                devices[service_info.address] = f"{device.name} ({service_info.address})"
+            except KeyError:
+                # Discovered device is not an AC Infinity device
+                pass
 
         data_schema = vol.Schema(
             {


### PR DESCRIPTION
Based on #2 there's a break in the BLE discovery loop. When there's more than one BLE device in range, it'll create an unhandled exception and discontinue looking for more devices. This PR handles the exception and adds some debug logging around that conditional. 